### PR TITLE
Update roarr

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "description": "Slonik SQL tag for constructing dynamic queries.",
   "devDependencies": {
     "@types/lodash": "^4.14.168",
+    "@types/node": "^16.9.0",
+    "@types/pg": "^8.6.1",
     "@types/sinon": "^9.0.10",
     "ava": "^3.15.0",
     "coveralls": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "lodash": "^4.17.20",
-    "roarr": "^4.0.1",
     "serialize-error": "^8.0.0"
   },
   "peerDependencies": {
-    "slonik": ">=22.4.4"
+    "roarr": ">=^7.0.3",
+    "slonik": ">=24.1.0"
   },
   "description": "Slonik SQL tag for constructing dynamic queries.",
   "devDependencies": {
@@ -36,7 +36,7 @@
     "nyc": "^15.1.0",
     "semantic-release": "^17.3.6",
     "sinon": "^9.0.1",
-    "slonik": "^23.5.4",
+    "slonik": "^24.1.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
   },

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,5 +1,7 @@
-import Logger from 'roarr';
+import {
+  Roarr,
+} from 'roarr';
 
-export default Logger.child({
+export default Roarr.child({
   package: 'slonik-sql-tag-raw',
 });


### PR DESCRIPTION
## Issue

`slonik-sql-tag-raw` is tethered to an older version of roarr. This causes a separate package installation & leads to separate logger instances, as it's not creating a child from the same instance as modern slonik. 

## Related
- #7

## Solution

Like was done for the `slonik` dependency, we move the dependency to `peerDependency`, to ensure that we're using the same package.

## ⚠️ NOTE ⚠️ 

Because of structural changes to the `roarr` package, the previous logic would not work with the new roarr logger. We therefore needed to set minimum versions to the latest. As a result, this should be released as a new major version.

## Changes

- Moved `roarr` to peer deps
- Bumped `slonik` and `roarr` to latest versions
- Updated logic to accommodate `roarr` new `child` export path
- Added types packages, as latest TS patch was not allowing compile without them