### PR TITLE
fix!: Correct roarr peerDependencies grammar for npm (fixes #15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "serialize-error": "^8.0.0"
   },
   "peerDependencies": {
-    "roarr": ">=^7.0.3",
+    "roarr": ">=7.0.3",
     "slonik": ">=24.1.0"
   },
   "description": "Slonik SQL tag for constructing dynamic queries.",


### PR DESCRIPTION
Looks like this is my mistake. It seems the syntax is not valid with `npm`. I use yarn, which does not have a problem with it, so I missed it.

Recommend publishing this as **v2.0** and **unpublishing the last patch**, as it was intended as major release and will likely break some builds (detailed in notice section of #14)