### PR TITLE
Fix type compatibility with Slonik ≥ 27.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "roarr": ">=7.0.3",
-    "slonik": ">=24.1.0"
+    "slonik": ">=27.0.0"
   },
   "description": "Slonik SQL tag for constructing dynamic queries.",
   "devDependencies": {
@@ -38,7 +38,7 @@
     "nyc": "^15.1.0",
     "semantic-release": "^17.3.6",
     "sinon": "^9.0.1",
-    "slonik": "^24.1.0",
+    "slonik": "^27.0.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
   },

--- a/src/sqlTags/raw.ts
+++ b/src/sqlTags/raw.ts
@@ -3,7 +3,7 @@ import type {
   ValueExpression,
 } from 'slonik';
 import type {
-  NamedParameterValuesType,
+  NamedParameterValues,
 } from '../types';
 import {
   interpolatePositionalParameterReferences,
@@ -12,11 +12,11 @@ import {
 
 export default (
   sql: string,
-  values?: NamedParameterValuesType | ReadonlyArray<ValueExpression>,
+  values?: NamedParameterValues | ReadonlyArray<ValueExpression>,
 ): SqlSqlToken => {
   if (Array.isArray(values)) {
     return interpolatePositionalParameterReferences(sql, values as ValueExpression[]);
   } else {
-    return interpolateNamedParameterReferences(sql, values as NamedParameterValuesType);
+    return interpolateNamedParameterReferences(sql, values as NamedParameterValues);
   }
 };

--- a/src/sqlTags/raw.ts
+++ b/src/sqlTags/raw.ts
@@ -1,6 +1,6 @@
 import type {
-  SqlSqlTokenType,
-  ValueExpressionType,
+  SqlSqlToken,
+  ValueExpression,
 } from 'slonik';
 import type {
   NamedParameterValuesType,
@@ -12,10 +12,10 @@ import {
 
 export default (
   sql: string,
-  values?: NamedParameterValuesType | ReadonlyArray<ValueExpressionType>,
-): SqlSqlTokenType => {
+  values?: NamedParameterValuesType | ReadonlyArray<ValueExpression>,
+): SqlSqlToken => {
   if (Array.isArray(values)) {
-    return interpolatePositionalParameterReferences(sql, values as ValueExpressionType[]);
+    return interpolatePositionalParameterReferences(sql, values as ValueExpression[]);
   } else {
     return interpolateNamedParameterReferences(sql, values as NamedParameterValuesType);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 import type {
-  ValueExpressionType,
+  ValueExpression,
   createSqlTokenSqlFragment,
 } from 'slonik';
 
 export type NamedParameterValuesType = {
-  [key: string]: ValueExpressionType,
+  [key: string]: ValueExpression,
 };
 
 export type PrimitiveValueExpressionType = ReturnType<typeof createSqlTokenSqlFragment>['values'][number];

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,8 @@ import type {
   createSqlTokenSqlFragment,
 } from 'slonik';
 
-export type NamedParameterValuesType = {
+export type NamedParameterValues = {
   [key: string]: ValueExpression,
 };
 
-export type PrimitiveValueExpressionType = ReturnType<typeof createSqlTokenSqlFragment>['values'][number];
+export type PrimitiveValueExpression = ReturnType<typeof createSqlTokenSqlFragment>['values'][number];

--- a/src/utilities/interpolateNamedParameterReferences.ts
+++ b/src/utilities/interpolateNamedParameterReferences.ts
@@ -2,7 +2,7 @@ import {
   difference,
 } from 'lodash';
 import type {
-  SqlSqlTokenType,
+  SqlSqlToken,
 } from 'slonik';
 import {
   InvalidInputError,
@@ -28,7 +28,7 @@ const namedPlaceholderRegex = /[\s(,]:([_a-z]+)/g;
 export default (
   inputSql: string,
   inputValues: NamedParameterValuesType = {},
-): SqlSqlTokenType => {
+): SqlSqlToken => {
   const resultValues = [];
   const parameterNames = Object.keys(inputValues);
 

--- a/src/utilities/interpolateNamedParameterReferences.ts
+++ b/src/utilities/interpolateNamedParameterReferences.ts
@@ -9,7 +9,7 @@ import {
 } from 'slonik';
 import Logger from '../Logger';
 import type {
-  NamedParameterValuesType,
+  NamedParameterValues,
 } from '../types';
 import interpolatePositionalParameterReferences from './interpolatePositionalParameterReferences';
 
@@ -27,7 +27,7 @@ const namedPlaceholderRegex = /[\s(,]:([_a-z]+)/g;
  */
 export default (
   inputSql: string,
-  inputValues: NamedParameterValuesType = {},
+  inputValues: NamedParameterValues = {},
 ): SqlSqlToken => {
   const resultValues = [];
   const parameterNames = Object.keys(inputValues);

--- a/src/utilities/interpolatePositionalParameterReferences.ts
+++ b/src/utilities/interpolatePositionalParameterReferences.ts
@@ -1,6 +1,6 @@
 import type {
-  SqlSqlTokenType,
-  ValueExpressionType,
+  SqlSqlToken,
+  ValueExpression,
 } from 'slonik';
 import {
   InvalidInputError,
@@ -16,8 +16,8 @@ import type {
  */
 export default (
   inputSql: string,
-  inputValues: ReadonlyArray<ValueExpressionType> = [],
-): SqlSqlTokenType => {
+  inputValues: ReadonlyArray<ValueExpression> = [],
+): SqlSqlToken => {
   const resultValues = [] as PrimitiveValueExpressionType[];
 
   const bindingNames = (inputSql.match(/\$(\d+)/g) ?? [])

--- a/src/utilities/interpolatePositionalParameterReferences.ts
+++ b/src/utilities/interpolatePositionalParameterReferences.ts
@@ -8,7 +8,7 @@ import {
   isSqlToken,
 } from 'slonik';
 import type {
-  PrimitiveValueExpressionType,
+  PrimitiveValueExpression,
 } from '../types';
 
 /**
@@ -18,7 +18,7 @@ export default (
   inputSql: string,
   inputValues: ReadonlyArray<ValueExpression> = [],
 ): SqlSqlToken => {
-  const resultValues = [] as PrimitiveValueExpressionType[];
+  const resultValues = [] as PrimitiveValueExpression[];
 
   const bindingNames = (inputSql.match(/\$(\d+)/g) ?? [])
     .map((match) => {
@@ -45,7 +45,7 @@ export default (
 
       return sqlFragment.sql;
     } else {
-      resultValues.push(inputValues[parameterPosition - 1] as PrimitiveValueExpressionType);
+      resultValues.push(inputValues[parameterPosition - 1] as PrimitiveValueExpression);
 
       return `$${resultValues.length}`;
     }


### PR DESCRIPTION
## Changes

- Fixes type imports for Slonik ≥ v27.0.0
- Keep consistent type naming scheme as Slonik (drop Type suffix from all types)

## Note

Recommend bumping major version since this change contains backwards incompatible changes with previous versions of Slonik.